### PR TITLE
Using more StateTriggers

### DIFF
--- a/XamarinTV/ViewModels/MainViewModel.cs
+++ b/XamarinTV/ViewModels/MainViewModel.cs
@@ -29,10 +29,10 @@ namespace XamarinTV.ViewModels
 
         TwoPaneViewMode _twoPaneViewMode;
         bool _settingsActive = false;
-        private bool spannedWithVideo;
-        private bool notSpannedWithVideo;
-        private bool spannedWithoutVideo;
-        private bool notSpannedWithoutVideo;
+        bool _spannedWithVideo;
+        bool _notSpannedWithVideo;
+        bool _spannedWithoutVideo;
+        bool _notSpannedWithoutVideo;
 
         public Command<Video> PlayVideoCommand { get; }
         public Command OpenSettingWindowCommand { get; }
@@ -90,10 +90,10 @@ namespace XamarinTV.ViewModels
 
         public bool DeviceIsSpanned => DualScreenInfo.Current.SpanMode != TwoPaneViewMode.SinglePane;
 
-        public bool SpannedWithVideo { get => spannedWithVideo; set => SetProperty(ref spannedWithVideo, value); }
-        public bool NotSpannedWithVideo { get => notSpannedWithVideo; set => SetProperty(ref notSpannedWithVideo, value); }
-        public bool SpannedWithoutVideo { get => spannedWithoutVideo; set => SetProperty(ref spannedWithoutVideo, value); }
-        public bool NotSpannedWithoutVideo { get => notSpannedWithoutVideo; set => SetProperty(ref notSpannedWithoutVideo, value); }
+        public bool SpannedWithVideo { get => _spannedWithVideo; set => SetProperty(ref _spannedWithVideo, value); }
+        public bool NotSpannedWithVideo { get => _notSpannedWithVideo; set => SetProperty(ref _notSpannedWithVideo, value); }
+        public bool SpannedWithoutVideo { get => _spannedWithoutVideo; set => SetProperty(ref _spannedWithoutVideo, value); }
+        public bool NotSpannedWithoutVideo { get => _notSpannedWithoutVideo; set => SetProperty(ref _notSpannedWithoutVideo, value); }
 
         public void UpdateLayouts()
         {

--- a/XamarinTV/ViewModels/VideoPlayerViewModel.cs
+++ b/XamarinTV/ViewModels/VideoPlayerViewModel.cs
@@ -8,10 +8,12 @@ namespace XamarinTV.ViewModels
     {
         Video _video;
         double _volume;
+        bool _isPlaying;
 
         public VideoPlayerViewModel()
         {
             Volume = 0.2d;
+            IsPlaying = true;
         }
 
         public Video Video
@@ -19,7 +21,7 @@ namespace XamarinTV.ViewModels
             get { return _video; }
             set
             {
-                if(SetProperty(ref _video, value))
+                if (SetProperty(ref _video, value))
                 {
                     OnPropertyChanged(nameof(VideoSource));
                 }
@@ -44,6 +46,15 @@ namespace XamarinTV.ViewModels
                     return null;
 
                 return "video.mp4";
+            }
+        }
+
+        public bool IsPlaying
+        {
+            get => _isPlaying;
+            set
+            {
+                SetProperty(ref _isPlaying, value);
             }
         }
 

--- a/XamarinTV/ViewModels/VideoPlayerViewModel.cs
+++ b/XamarinTV/ViewModels/VideoPlayerViewModel.cs
@@ -13,7 +13,7 @@ namespace XamarinTV.ViewModels
         public VideoPlayerViewModel()
         {
             Volume = 0.2d;
-            IsPlaying = true;
+            IsPlaying = true;   // AutoPlay
         }
 
         public Video Video

--- a/XamarinTV/Views/MainPage.xaml.cs
+++ b/XamarinTV/Views/MainPage.xaml.cs
@@ -2,7 +2,6 @@
 using XamarinTV.ViewModels.Base;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
-using System.ComponentModel;
 
 namespace XamarinTV.Views
 {
@@ -14,7 +13,6 @@ namespace XamarinTV.Views
             InitializeComponent();
             BindingContext = MainViewModel.Instance;
             twoPaneView.LayoutChanged += OnTwoPaneViewLayoutChanged;
-
         }
 
         void OnTwoPaneViewLayoutChanged(object sender, System.EventArgs e)

--- a/XamarinTV/Views/VideoPlayerView.xaml
+++ b/XamarinTV/Views/VideoPlayerView.xaml
@@ -89,6 +89,7 @@
                     Property="Margin"
                     Value="0,10,10,0" />
             </Style>
+
         </ResourceDictionary>
     </ContentView.Resources>
     <ContentView.Content>
@@ -123,8 +124,11 @@
                     <Grid.RowDefinitions>
                         <RowDefinition />
                     </Grid.RowDefinitions>
-                    <BoxView BackgroundColor="Black" Opacity="0.6"/>
-                    <ImageButton x:Name="PlayPauseToggle" 
+                    <BoxView
+                        BackgroundColor="Black"
+                        Opacity="0.6"/>
+                    <ImageButton
+                        x:Name="PlayPauseToggle" 
                          Source="{StaticResource PauseIcon}" 
                          Clicked="PlayPauseToggle_Clicked"
                          BackgroundColor="Transparent"
@@ -132,12 +136,18 @@
                          VerticalOptions="Center">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="PlaybackStates">
-                                <VisualState Name="paused">
+                                <VisualState Name="Paused">
+                                    <VisualState.StateTriggers>
+                                        <CompareStateTrigger Property="{Binding IsPlaying}" Value="False"/>
+                                    </VisualState.StateTriggers>
                                     <VisualState.Setters>
                                         <Setter Property="Source" Value="{StaticResource PlayIcon}"/>
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState Name="playing">
+                                <VisualState Name="Playing">
+                                    <VisualState.StateTriggers>
+                                        <CompareStateTrigger Property="{Binding IsPlaying}" Value="True"/>
+                                    </VisualState.StateTriggers>
                                     <VisualState.Setters>
                                         <Setter Property="Source" Value="{StaticResource PauseIcon}"/>
                                     </VisualState.Setters>
@@ -145,13 +155,14 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                     </ImageButton>
-                    <Label x:Name="TimeAndDuration" Text="Loading..."
-                       TextColor="White" 
-                       FontSize="14"
-                       Margin="15"
-                       VerticalOptions="End"
-                       HorizontalOptions="End"/>
-
+                    <Label
+                        x:Name="TimeAndDuration"
+                        Text="Loading..."
+                        TextColor="White" 
+                        FontSize="14"
+                        Margin="15"
+                        VerticalOptions="End"
+                        HorizontalOptions="End"/>
                     <Label
                         Text="{Binding Video.Title}"
                         Style="{StaticResource TitleStyle}" />

--- a/XamarinTV/Views/VideoPlayerView.xaml.cs
+++ b/XamarinTV/Views/VideoPlayerView.xaml.cs
@@ -4,13 +4,14 @@ using System.Threading.Tasks;
 using System.Timers;
 using Xamarin.Forms;
 using Xamarin.Forms.DualScreen;
+using XamarinTV.ViewModels;
 
 namespace XamarinTV.Views
 {
     public partial class VideoPlayerView : ContentView
     {
-        Timer _inactivityTimer;
-        Timer _playbackTimer;
+        readonly Timer _inactivityTimer;
+        readonly Timer _playbackTimer;
 
         public VideoPlayerView()
         {
@@ -87,12 +88,12 @@ namespace XamarinTV.Views
             UpdateAspectRatio();
         }
 
-        private void OnPlaybackTimerElapsed(object sender, ElapsedEventArgs e)
+        void OnPlaybackTimerElapsed(object sender, ElapsedEventArgs e)
         {
-            this.UpdateTimeDisplay();
+            UpdateTimeDisplay();
         }
 
-        private async void OnInactivityTimerElapsed(object sender, ElapsedEventArgs e)
+        async void OnInactivityTimerElapsed(object sender, ElapsedEventArgs e)
         {
             await Task.WhenAny<bool>
             (
@@ -105,12 +106,9 @@ namespace XamarinTV.Views
                 _inactivityTimer.Start();
         }
 
-        private void MediaElement_StateRequested(object sender, StateRequested e)
+        void MediaElement_StateRequested(object sender, StateRequested e)
         {
-            VisualStateManager.GoToState(PlayPauseToggle,
-                (e.State == MediaElementState.Playing)
-                ? "playing"
-                : "paused");
+            ((VideoPlayerViewModel)BindingContext).IsPlaying = e.State == MediaElementState.Playing;
 
             if (e.State == MediaElementState.Playing)
             {


### PR DESCRIPTION
After recently added **StateTriggers** to simplify the management of visual states, in this PR we include more StateTriggers in XamarinTV.

```
<VisualStateManager.VisualStateGroups>
    <VisualStateGroup Name="PlaybackStates">
        <VisualState Name="Paused">
            <VisualState.StateTriggers>
                <CompareStateTrigger Property="{Binding IsPlaying}" Value="False"/>
            </VisualState.StateTriggers>
            <VisualState.Setters>
                <Setter Property="Source" Value="{StaticResource PlayIcon}"/>
            </VisualState.Setters>
        </VisualState>
        <VisualState Name="Playing">
            <VisualState.StateTriggers>
                <CompareStateTrigger Property="{Binding IsPlaying}" Value="True"/>
            </VisualState.StateTriggers>
            <VisualState.Setters>
                <Setter Property="Source" Value="{StaticResource PauseIcon}"/>
            </VisualState.Setters>
        </VisualState>
    </VisualStateGroup>
</VisualStateManager.VisualStateGroups>
```